### PR TITLE
Remove docs job from GitHub Actions

### DIFF
--- a/.github/workflows/pr_codebase.yml
+++ b/.github/workflows/pr_codebase.yml
@@ -89,14 +89,3 @@ jobs:
         run: cargo build --verbose
       - name: "Ravana test"
         run: cargo test --verbose --no-fail-fast
-  docs:
-    needs: changes
-    if: ${{ needs.changes.outputs.docs == 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Check spelling of .md files
-        uses: crate-ci/typos@master
-        with:
-          files: docs/**.md

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -13,7 +13,7 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: actions/checkout@v2
       - name: TODO to Issue
-        uses: alstr/todo-to-issue-action@v4.5
+        uses: "alstr/todo-to-issue-action@v4.6.2"
         id: todo
       - name: Run Changelog CI
         uses: saadmk11/changelog-ci@v1.0.0

--- a/.github/workflows/push_codebase.yml
+++ b/.github/workflows/push_codebase.yml
@@ -68,15 +68,6 @@ jobs:
         run: cargo build --verbose
       - name: "Ravana test"
         run: cargo test --verbose
-  docs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Check spelling of .md files
-        uses: crate-ci/typos@master
-        with:
-          files: docs/**.md
   other:
     runs-on: ubuntu-latest
     steps:
@@ -85,3 +76,6 @@ jobs:
       uses: githubocto/repo-visualizer@0.7.1
       with:
         output_file: "docs/repo_visualize.svg"
+    - name: TODO to Issue
+      uses: "alstr/todo-to-issue-action@v4.6.2"
+      id: todo


### PR DESCRIPTION
- Remove docs jobs.
- Move TODO to Issue to push workflow.